### PR TITLE
:construction: CitydataParser가 강수량 메시지 추적하도록 변경

### DIFF
--- a/src/main/java/org/example/what_seoul/domain/citydata/weather/PcpMsgHistory.java
+++ b/src/main/java/org/example/what_seoul/domain/citydata/weather/PcpMsgHistory.java
@@ -1,0 +1,32 @@
+package org.example.what_seoul.domain.citydata.weather;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 강수량 메시지
+ */
+@Entity
+@Table(name = "pcp_msg_history")
+@Getter
+@NoArgsConstructor
+public class PcpMsgHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "pcp_msg", unique = true, nullable = false)
+    private String pcpMsg;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    public PcpMsgHistory(String pcpMsg) {
+        this.pcpMsg = pcpMsg;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/org/example/what_seoul/repository/citydata/weather/PcpMsgHistoryRepository.java
+++ b/src/main/java/org/example/what_seoul/repository/citydata/weather/PcpMsgHistoryRepository.java
@@ -1,0 +1,8 @@
+package org.example.what_seoul.repository.citydata.weather;
+
+import org.example.what_seoul.domain.citydata.weather.PcpMsgHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PcpMsgHistoryRepository extends JpaRepository<PcpMsgHistory, Long> {
+    boolean existsByPcpMsg(String pcpMsg);
+}

--- a/src/main/java/org/example/what_seoul/service/citydata/CitydataParser.java
+++ b/src/main/java/org/example/what_seoul/service/citydata/CitydataParser.java
@@ -23,6 +23,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class CitydataParser {
+    private final PcpMsgHistoryService pcpMsgHistoryService;
+
     /**
      * XML 문서에서 인구 데이터를 파싱하여 Population 객체 생성
      * @param document
@@ -163,7 +165,7 @@ public class CitydataParser {
             String pcpMsg = weatherData.getOrDefault(XmlElementNames.PCP_MSG, "No Tag");
 
             // 히스토리 저장
-//            pcpMsgHistoryService.saveIfNotExists(pcpMsg);
+            pcpMsgHistoryService.saveIfNotExists(pcpMsg);
 
             // Map에서 주어진 key(XmlElementNames)에 해당하는 값을 가져오고, 만약 해당 key가 없다면 "No Tag"를 기본값으로 반환
             return new Weather(

--- a/src/main/java/org/example/what_seoul/service/citydata/PcpMsgHistoryService.java
+++ b/src/main/java/org/example/what_seoul/service/citydata/PcpMsgHistoryService.java
@@ -1,0 +1,19 @@
+package org.example.what_seoul.service.citydata;
+
+import lombok.RequiredArgsConstructor;
+import org.example.what_seoul.domain.citydata.weather.PcpMsgHistory;
+import org.example.what_seoul.repository.citydata.weather.PcpMsgHistoryRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PcpMsgHistoryService {
+    private final PcpMsgHistoryRepository pcpMsgHistoryRepository;
+
+    public void saveIfNotExists(String pcpMsg) {
+        if (!pcpMsgHistoryRepository.existsByPcpMsg(pcpMsg)) {
+            pcpMsgHistoryRepository.save(new PcpMsgHistory(pcpMsg));
+        }
+    }
+
+}


### PR DESCRIPTION
## 구현사항
- unversioned 상태였던 강수량 메시지 관련 클래스 반영
- 도시데이터 스케줄러와 연결된 파서에서 강수량 메시지를 추적하도록 주석 해제