### PR TITLE
🔐 AWS 버킷 관련 yml 변경

### DIFF
--- a/src/main/java/org/example/what_seoul/service/admin/AdminService.java
+++ b/src/main/java/org/example/what_seoul/service/admin/AdminService.java
@@ -55,6 +55,12 @@ public class AdminService {
     @Value("${cloud.aws.s3.bucket}")
     private String s3BucketName;
 
+    @Value("${cloud.aws.s3.shapefile-key-prefix")
+    private String s3ShapefileKeyPrefix;
+
+    @Value("${cloud.aws.ec2.shapefile-path-prefix}")
+    private String ec2ShapefilePathPrefix;
+
     @Value("${file.storage.shp-temp-path}")
     private String shpTempPath;
 
@@ -250,7 +256,7 @@ public class AdminService {
     @Transactional
     public CommonResponse<ResUploadAreaDTO> processAreaFile(MultipartFile multipartFile) {
         String uuid = UUID.randomUUID().toString();
-        String s3Key = "admin/shapefiles/" + uuid + ".zip";
+        String s3Key = s3ShapefileKeyPrefix + uuid + ".zip";
 
         File tempZip = null;
         File downloadDir = null;
@@ -264,7 +270,7 @@ public class AdminService {
             log.info("파일이 S3에 업로드되었습니다: s3://{}/{}", s3BucketName, s3Key);
 
             // 2. S3에서 EC2로 다운로드
-            downloadDir = new File("/tmp/admin/shapefiles/" + uuid);
+            downloadDir = new File(ec2ShapefilePathPrefix + uuid);
             downloadDir.mkdirs();
             File localZip = new File(downloadDir, "uploaded.zip");
             amazonS3Client.getObject(new GetObjectRequest(s3BucketName, s3Key), localZip);


### PR DESCRIPTION
## 변경사항
- aws s3 bucket shapefile 저장 경로 및 aws ec2 서버 내 shapefile 임시 저장 경로 yml 변수화
  - 향후 개발용 서버와 운영용 서버를 분리하기 전까지는 경로 prefix에 /dev 또는 /prod를 사용해 경로를 구분하기로 결정
  - 서버를 아예 분리할 경우 s3 bucket 저장 경로에는 계속 prefix를 적용하더라도, ec2 서버 내 임시 저장 경로에는 prefix를 적용할 필요가 없을 것으로 예상
  - bucket까지 분리한다면 마찬가지로 두 경로 모두 prefix를 적용할 필요가 없을 것으로 예상 (버킷 분리는 아직 미정)