### PR TITLE
🐛 마이페이지 UI 개선 및 기능 오류 수정

### DIFF
--- a/src/main/java/org/example/what_seoul/controller/user/UserController.java
+++ b/src/main/java/org/example/what_seoul/controller/user/UserController.java
@@ -84,8 +84,8 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = UserDescription.WITHDRAW_USER_SUCCESS),
     })
     @PutMapping("/withdraw")
-    public ResponseEntity<CommonResponse<ResWithdrawUserDTO>> withdrawUser(HttpServletRequest request, HttpServletResponse response) {
-        return ResponseEntity.status(HttpStatus.OK).body(userService.withdrawUser(request, response));
+    public ResponseEntity<CommonResponse<ResWithdrawUserDTO>> withdrawUser(@RequestBody ReqWithdrawUserDTO req,  HttpServletRequest request, HttpServletResponse response) {
+        return ResponseEntity.status(HttpStatus.OK).body(userService.withdrawUser(req, request, response));
     }
 
     @Operation(summary = "아이디 찾기", description = "이메일로 사용자 아이디를 조회하고 메일로 전송합니다.")

--- a/src/main/java/org/example/what_seoul/service/admin/AdminService.java
+++ b/src/main/java/org/example/what_seoul/service/admin/AdminService.java
@@ -166,6 +166,10 @@ public class AdminService {
             throw new IllegalArgumentException("관리자 계정이 아닙니다.");
         }
 
+        if (admin.getDeletedAt() != null) {
+            throw new IllegalArgumentException("탈퇴한 계정입니다.");
+        }
+
         if (!encoder.matches(req.getPassword(), admin.getPassword())) {
             throw new IllegalArgumentException("잘못된 비밀번호입니다.");
         }

--- a/src/main/java/org/example/what_seoul/service/user/UserService.java
+++ b/src/main/java/org/example/what_seoul/service/user/UserService.java
@@ -124,6 +124,10 @@ public class UserService {
             throw new IllegalArgumentException("일반 회원 계정이 아닙니다.");
         }
 
+        if (user.getDeletedAt() != null) {
+            throw new IllegalArgumentException("탈퇴한 계정입니다.");
+        }
+
         if (!encoder.matches(req.getPassword(), user.getPassword())) {
             throw new IllegalArgumentException("잘못된 비밀번호입니다.");
         }

--- a/src/main/java/org/example/what_seoul/service/user/UserService.java
+++ b/src/main/java/org/example/what_seoul/service/user/UserService.java
@@ -310,9 +310,14 @@ public class UserService {
      * @return 회원 탈퇴 성공 시 CommonResponse를, 실패 시 CommonErrorResponse를 반환한다.
      */
     @Transactional
-    public CommonResponse<ResWithdrawUserDTO> withdrawUser(HttpServletRequest request, HttpServletResponse response) {
+    public CommonResponse<ResWithdrawUserDTO> withdrawUser(ReqWithdrawUserDTO req, HttpServletRequest request, HttpServletResponse response) {
         Long id = getLoginUserInfo().getId();
         User user = userRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (!encoder.matches(req.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
         if (user.getDeletedAt() != null) {
             throw new IllegalStateException("이미 탈퇴한 사용자입니다.");
         }

--- a/src/main/resources/static/js/admin/signup.js
+++ b/src/main/resources/static/js/admin/signup.js
@@ -26,7 +26,7 @@ document.addEventListener("DOMContentLoaded", function () {
             .then(({ status, body }) => {
                 if (status === 201) {
                     alert('신규 관리자 계정 생성이 완료되었습니다.');
-                    // window.location.href = "/login"; // 로그인 페이지 이동
+                    window.location.href = "/mypage"; // 마이페이지 이동
                 } else if (status === 400) {
                     displayErrors(body.context); // 서버에서 받은 에러 메시지 표시
                 } else {

--- a/src/main/resources/static/js/admin/signup.js
+++ b/src/main/resources/static/js/admin/signup.js
@@ -25,17 +25,17 @@ document.addEventListener("DOMContentLoaded", function () {
                     ))
             .then(({ status, body }) => {
                 if (status === 201) {
-                    alert('회원가입이 완료되었습니다.');
-                    window.location.href = "/login"; // 로그인 페이지 이동
+                    alert('신규 관리자 계정 생성이 완료되었습니다.');
+                    // window.location.href = "/login"; // 로그인 페이지 이동
                 } else if (status === 400) {
                     displayErrors(body.context); // 서버에서 받은 에러 메시지 표시
                 } else {
-                    alert("회원가입 실패: " + (body.message || "알 수 없는 오류"));
+                    alert("신규 관리자 계정 생성 실패: " + (body.message || "알 수 없는 오류"));
                 }
             })
             .catch(error => {
-                console.error("회원가입 요청 중 오류 발생:", error);
-                alert("회원가입 요청에 실패했습니다.");
+                console.error("신규 관리자 계정 생성 요청 중 오류 발생:", error);
+                alert("신규 관리자 계정 생성 요청에 실패했습니다.");
 
             });
     });

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -391,6 +391,17 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 function withdrawUser() {
+    $('#withdrawModal').modal('show');
+}
+
+function submitWithdrawUser() {
+    const password = document.getElementById("withdrawPassword").value;
+
+    if (!password) {
+        alert("비밀번호를 입력해주세요.");
+        return;
+    }
+
     if (confirm("정말 탈퇴하시겠습니까?") === true) {
         fetch('/api/user/withdraw', {
             method: 'PUT',
@@ -398,6 +409,7 @@ function withdrawUser() {
             headers: {
                 "Content-Type": "application/json"
             },
+            body: JSON.stringify({password: password})
         }).then(response => response.json()
             .then(data => ({status: response.status, body: data}))
             .then(({status, body}) => {
@@ -412,20 +424,24 @@ function withdrawUser() {
                             sessionStorage.removeItem("accessTokenExpiration");
                             sessionStorage.removeItem("loginStartTime");
 
-                            // alert("로그아웃이 완료되었습니다.")
                             window.location.href = '/';
                         }
                     }).catch(error => {
                         console.log("Error: ", error);
                     });
                 } else {
-                    alert(body.message || "회원탈퇴에 실패했습니다.");
+                    alert(body.context || "회원탈퇴에 실패했습니다.");
                 }
             })
             .catch(error => {
                 console.log("Error: ", error);
                 alert("회원탈퇴에 실패했습니다.");
-            }));
+            })
+            .finally(() => {
+                document.getElementById("withdrawPassword").value = "";
+                $('#withdrawModal').modal('hide');
+            }))
+        ;
     }
 
 }

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -322,7 +322,15 @@ document.addEventListener("DOMContentLoaded", function () {
                                 }
 
                                 alert("후기가 수정되었습니다.");
-                                reviewContent.innerText = newContent;
+                                reviewContent.innerText = newContent; // 후기 내용 갱신해서 화면에 보여주기
+
+                                const updatedAt = new Date(response.data.updatedAt).toLocaleString(); // 작성일자 갱신해서 화면에 보여주기
+                                const dateDisplay = reviewItem.querySelector("small.text-muted");
+                                dateDisplay.innerHTML = `
+                                    작성일자: ${new Date(item.createdAt).toLocaleString()}<br/>
+                                    수정일자: ${updatedAt}
+                                `;
+
                                 editForm.classList.add("d-none");
                                 reviewContent.classList.remove("d-none");
                                 buttonGroup.classList.remove("d-none");

--- a/src/main/resources/static/js/user/mypage.js
+++ b/src/main/resources/static/js/user/mypage.js
@@ -32,7 +32,21 @@ document.addEventListener("DOMContentLoaded", function () {
             .then(({status, body}) => {
                 if (status === 200) {
                     alert("회원정보가 수정되어 로그아웃합니다.");
-                    window.location.href = "/logout";
+                    fetch('/api/auth/logout', {
+                        method: 'POST',
+                        credentials: "include"
+                    }).then(response => {
+                        if (response.ok) {
+                            // 세션스토리지 비우기
+                            sessionStorage.removeItem("accessTokenExpiration");
+                            sessionStorage.removeItem("loginStartTime");
+
+                            alert("로그아웃이 완료되었습니다.")
+                            window.location.href = '/';
+                        }
+                    }).catch(error => {
+                        console.log("Error: ", error);
+                    });
                 } else if (status === 400) {
                     displayErrors(body.context);
                 }
@@ -380,8 +394,22 @@ function withdrawUser() {
             .then(data => ({status: response.status, body: data}))
             .then(({status, body}) => {
                 if (status === 200) {
-                    alert("회원 탈퇴가 완료되었습니다.");
-                    window.location.href = "/";
+                    alert("회원 탈퇴가 완료되어 홈으로 이동합니다.");
+                    fetch('/api/auth/logout', {
+                        method: 'POST',
+                        credentials: "include"
+                    }).then(response => {
+                        if (response.ok) {
+                            // 세션스토리지 비우기
+                            sessionStorage.removeItem("accessTokenExpiration");
+                            sessionStorage.removeItem("loginStartTime");
+
+                            // alert("로그아웃이 완료되었습니다.")
+                            window.location.href = '/';
+                        }
+                    }).catch(error => {
+                        console.log("Error: ", error);
+                    });
                 } else {
                     alert(body.message || "회원탈퇴에 실패했습니다.");
                 }

--- a/src/test/java/org/example/what_seoul/controller/user/UserControllerTest.java
+++ b/src/test/java/org/example/what_seoul/controller/user/UserControllerTest.java
@@ -195,15 +195,17 @@ class UserControllerTest {
         // Given - 탈퇴한 유저 Mock 데이터 생성
         User withdrawnUser = new User("test", "newPassword123!", "newemail@test.com", "newNickname", RoleType.USER);
         withdrawnUser.deactivate(); // 탈퇴 처리
+        ReqWithdrawUserDTO req = new ReqWithdrawUserDTO("newPassword123!");
         ResWithdrawUserDTO res = ResWithdrawUserDTO.from(withdrawnUser);
         CommonResponse<ResWithdrawUserDTO> commonResponse = new CommonResponse<>(true, "회원 탈퇴 성공", res);
 
         // When & Then
-        when(userService.withdrawUser(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+        when(userService.withdrawUser(any(ReqWithdrawUserDTO.class), any(HttpServletRequest.class), any(HttpServletResponse.class)))
                 .thenReturn(commonResponse);
 
         mockMvc.perform(MockMvcRequestBuilders.put("/api/user/withdraw")
-                        .contentType(MediaType.APPLICATION_JSON))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(req)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))


### PR DESCRIPTION
## 수정사항
1. 회원정보 수정 및 회원 탈퇴 이후에 로그아웃 정상 처리되도록 수정 (마이페이지 회원정보 수정 / 회원탈퇴 기능)
    - 기존 문제 상황 : 회원정보 수정 이후 접근 권한 없음 페이지로 이동
    - 원인 : 로그아웃 기능을 새로 구현하고 필터체인상에서 시큐리티가 제공하는 로그아웃 기능은 비활성화해두었는데 /logout 엔드포인트를 호출하고 있기 때문이었음 (기존 코드는 회원탈퇴 이후에 /logout 엔드포인트를 호출하고 인덱스로 화면을 이동시켰음)
    - 해결 : 접근 권한이 없어져 버린 /logout 엔드포인트를 호출하는 대신,  새로 구현한 로그아웃 기능의 엔드포인트를 호출하고 인덱스로 이동시킴.

2. 내가 작성한 후기 목록 조회 모달에서 직접 후기 수정할 경우 수정일자가 반영되지 않는 문제 해결 (마이페이지 내가 작성한 후기 조회 기능)
    - createdAt, updatedAt을 다시 받아와서 DOM에 그려주는 과정이 필요했음.

3. 탈퇴처리 과정 변경 (마이페이지 탈퇴처리 기능)
    - 기존 방식 : confirm문을 사용해서 탈퇴처리 승인만 하면 ok 
    - 변경점 : 요청 DTO로 현재 비밀번호를 전달, 일치하지 않으면 예외처리
    - 변경된 방식 :  탈퇴 모달의 input에 비밀번호를 입력 -> 입력 X시 리턴 / 잘못 입력할 경우 에러 컨텍스트를 alert에 출력 -> confirm을 통해 회원 탈퇴를 확인 -> 최종적으로 탈퇴처리
    -  관련된 추가 변경사항 : 탈퇴처리 테스트코드 수정 + 탈퇴처리된 계정으로 로그인 불가하도록 수정


4. 신규 관리자 계정 생성 이후 redirection 방지 (관리자 Settings > 관리자 계정 생성 기능)

    - 기존 방식 : 신규 관리자 계정 생성 이후 로그인 페이지로 이동

    - 문제점 : 바로 /login으로 이동할 경우, authenticationentrypoint 상에서 commence 메소드에 의해 /login 경로로 계속 리다이렉트 되는 오류 발생
    -  변경된 방식 : 신규 관리자 계정 생성 이후 마이페이지로 이동
        - 현재 관리자 계정에 로그인되어있는 상태를 유지하고, 직접 로그아웃한 이후에 새로운 관리자 계정으로 로그인하는 플로우가 적합하다고 판단
